### PR TITLE
removed invalid engines property

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
     "express": "^4.0.0",
     "mocha": "^3.3.0"
   },
-  "engines": {
-    "ejs": "2.5.5"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/heroku/node-js-sample"


### PR DESCRIPTION
The `engines` field was probably defined with `ejs` by accident. 

Per NPM:

> If you specify an "engines" field, then npm will require that "node" be somewhere on that list. If "engines" is omitted, then npm will just assume that it works on node.

You can read more here: https://docs.npmjs.com/files/package.json#engines